### PR TITLE
Add README & LICENSE for precompiled Micropython Adafruit libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+lib/**/*.mpy
+lib/**/*.py
 lib64/
 parts/
 sdist/
@@ -127,3 +128,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store

--- a/lib/LICENSE
+++ b/lib/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Limor Fried for Adafruit Industries
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,26 @@
+# Adafruit Macropad Libraries
+
+These MicroPython compiled libraries are provided as a convenience when
+installing this version of Macropad Hotkeys. See the Macropad
+[Adafruit Learning System Guide](https://learn.adafruit.com/macropad-hotkeys/project-code)
+for additional details.
+
+If you are installing straight from this repository, you can download the
+libraries as a bundle from the
+[CircuitPython library bundle](https://circuitpython.org/libraries).
+
+The libraries required by this version of Macropad Hotkeys includes:
+- adafruit_debouncer.mpy
+- adafruit_display_shapes
+- adafruit_display_text
+- adafruit_displayio_layout
+- adafruit_hid
+- adafruit_macropad.mpy
+- adafruit_midi
+- adafruit_pixelbuf.mpy
+- adafruit_simple_text_display.mpy
+- neopixel.mpy
+
+These libraries are individually licensed in each of their GitHub repositories
+and are provided by Adafruit under the MIT license
+(see also [LICENSE](./LICENSE) in this directory)


### PR DESCRIPTION
Structure the lib/ directory so its easier to package a release without committing MicroPython compiled libraries