### PR TITLE
explicitly release encoder button

### DIFF
--- a/code.py
+++ b/code.py
@@ -82,10 +82,12 @@ while True: # Input event loop
     event = macropad.keys.events.get()
     
     if (event and event.released) or last_position != macropad.encoder or macropad.encoder_switch_debounced.released:
-        keys.release(Keys.KEY_SLEEP)                 # Don't go to sleep!
+        keys.press(Keys.KEY_RESUME)                  # Don't go to sleep!
+        keys.release(Keys.KEY_RESUME)
         sleep_remaining = apps[app_index].timeout
     if sleep_remaining <= 0:                         # Go to sleep and slow down
         keys.press(Keys.KEY_SLEEP)
+        keys.release(Keys.KEY_SLEEP)
         time.sleep(1.0)
     elif event and event.pressed:                    # Key was pressed
         keys.press(event.key_number)

--- a/code.py
+++ b/code.py
@@ -115,5 +115,6 @@ while True: # Input event loop
         macro_changed = False
     elif macropad.encoder_switch_debounced.released: # Encoder button "pressed"
         keys.press(Keys.KEY_ENC_BUTTON)
+        keys.release(Keys.KEY_ENC_BUTTON)
 
     keys.tick(seconds_elapsed)

--- a/commands.py
+++ b/commands.py
@@ -34,6 +34,8 @@ class Commands:
             return item
         elif isinstance(item, Sleep):
             return item
+        elif isinstance(item, Resume):
+            return item
         elif isinstance(item, float):
             return Pause(item)
         elif isinstance(item, list):
@@ -90,5 +92,9 @@ class Pause(Command):
         self.keycode = seconds
 
 class Sleep(Command):
+    def __init__(self):
+        pass
+
+class Resume(Command):
     def __init__(self):
         pass

--- a/hid.py
+++ b/hid.py
@@ -1,4 +1,4 @@
-from commands import Commands, Command, Toolbar, Keyboard, Midi, Mouse, Pause, Sequence, Sleep
+from commands import Commands, Command, Toolbar, Keyboard, Midi, Mouse, Pause, Sequence, Sleep, Resume
 import time
 
 class InputDeviceListener:
@@ -35,6 +35,9 @@ class InputDeviceListener:
             self.release(command)
 
     def press(self, command: Command):
+        # Handle resume before checking if we're asleep
+        if isinstance(command, Resume): return self.resume(command)
+
         if self.sleeping: return # Ignore any button presses until we wake up
 
         if isinstance(command, Keyboard): return self.pressKeyboard(command)
@@ -50,7 +53,6 @@ class InputDeviceListener:
         elif isinstance(command, Toolbar): return self.releaseToolbar(command)
         elif isinstance(command, Mouse): return self.releaseMouse(command)
         elif isinstance(command, Midi): return self.releaseMidi(command)
-        elif isinstance(command, Sleep): return self.resume(command)
         
     def pressToolbar(self, command:Toolbar):
         if command.keycode < 0:
@@ -106,5 +108,5 @@ class InputDeviceListener:
     def sleep(self, command:Sleep):
         self.sleeping = True
 
-    def resume(self, command:Sleep):
+    def resume(self, command:Resume):
         self.sleeping = False

--- a/keys.py
+++ b/keys.py
@@ -1,4 +1,4 @@
-from commands import Commands, Sleep
+from commands import Commands, Sleep, Resume
 import time
 
 class Key:
@@ -13,13 +13,14 @@ class Keys:
     KEY_ENC_RIGHT  = 14 # Virtual key for encoder rotation right
     KEY_LAUNCH     = 15 # Hidden key for launching a new page
     KEY_SLEEP      = 16 # Hidden key for sleeping
+    KEY_RESUME     = 17 # Hidden key for resuming
     
     listeners = None
     keys = None
     tick_count = None
 
     def __init__(self, app):
-        self.keys = [None] * 17
+        self.keys = [None] * 18
         self.listeners = []
 
         for i in range(len(app.macros)):
@@ -28,6 +29,7 @@ class Keys:
 
         self.keys[Keys.KEY_LAUNCH] = Key(app.launch[2]) if app.launch else Key([])
         self.keys[Keys.KEY_SLEEP] = Key(Sleep())
+        self.keys[Keys.KEY_RESUME] = Key(Resume())
 
         self.tick_count = 0
 

--- a/pixels.py
+++ b/pixels.py
@@ -1,4 +1,4 @@
-from commands import Sleep
+from commands import Sleep, Resume
 
 class PixelListener:
     BRIGHTNESS = 0.3
@@ -37,13 +37,17 @@ class PixelListener:
         self.pixels.show()
 
     def pressed(self, keys, index):
+        commands = keys[index].commands
+        if not commands: return
+
+        # Handle resume before checking if we're asleep
+        if isinstance(commands[0], Resume):
+            self.resume()
+
         # Ignore any button presses until we wake up
         if self.sleeping: return
 
         self.highlight(index)
-
-        commands = keys[index].commands
-        if not commands: return
 
         if isinstance(commands[0], Sleep):
             self.sleep()
@@ -53,9 +57,6 @@ class PixelListener:
 
         commands = keys[index].commands
         if not commands: return
-        
-        if isinstance(commands[0], Sleep):
-            self.resume()
     
     def tick(self, keys, frames):
         for shader in self.shaders:

--- a/screen.py
+++ b/screen.py
@@ -2,7 +2,7 @@ import displayio
 import terminalio
 from adafruit_display_text import label
 from adafruit_display_shapes.rect import Rect
-from commands import Sleep
+from commands import Sleep, Resume
 
 class ScreenListener:
     MAX_LABELS = 12
@@ -60,13 +60,17 @@ class ScreenListener:
         self.display.refresh()
 
     def pressed(self, keys, index):
+        commands = keys[index].commands
+        if not commands: return
+
+        # Handle resume before checking if we're asleep
+        if isinstance(commands[0], Resume):
+            self.resume()
+
         # Ignore any button presses until we wake up
         if self.macropad.display_sleep: return
 
         self.highlight(index)
-
-        commands = keys[index].commands
-        if not commands: return
 
         if isinstance(commands[0], Sleep):
             self.sleep()
@@ -76,9 +80,6 @@ class ScreenListener:
 
         commands = keys[index].commands
         if not commands: return
-        
-        if isinstance(commands[0], Sleep):
-            self.resume()
 
     def tick(self, keys, frames):
         pass

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -30,7 +30,7 @@ class TestKeys(TestCase):
         keys = Keys(app)
         keys.addListener(MockListener())
         
-        self.assertEqual(len(keys.keys), 17)
+        self.assertEqual(len(keys.keys), 18)
         self.assertEqual(keys.keys[0].color, 0x0F0F0F)
         self.assertIsInstance(keys.keys[0].commands, Commands)
 


### PR DESCRIPTION
A macro on the encoder button triggers on a debounced release. Explicitly release the macro key, so it doesn't become stuck down.