### PR TITLE
fix minimal example

### DIFF
--- a/macros/examples/minimal.py
+++ b/macros/examples/minimal.py
@@ -2,7 +2,6 @@
 
 from adafruit_hid.keycode import Keycode
 from adafruit_hid.consumer_control_code import ConsumerControlCode
-from mouse_extended import Mouse as MouseCode
 
 from consumer import Toolbar
 from mouse import Mouse
@@ -26,6 +25,10 @@ app = {
         (0x000000, '       ', []),
         (0x000000, '       ', []),
         # 4th row ----------
+        (0x000000, '       ', []),
+        (0x000000, '       ', []),
+        (0x000000, '       ', []),
+        # encoder ----------
         (0x000000, '       ', []),
         (0x000000, '       ', []),
         (0x000000, '       ', []),


### PR DESCRIPTION
Remove the unneeded (missing) mouse_extended import.

Update the minimal example macros to define entries for the encoder. Without these lines, the code outputs a cryptic error when the macro is loaded. (`'NoneType' object has no attribute 'color'`)

In the future, the code should gracefully handle missing key definitions, for backward compatibility.