### PR TITLE
release keys in reverse order

### DIFF
--- a/hid.py
+++ b/hid.py
@@ -31,7 +31,7 @@ class InputDeviceListener:
             self.press(command)
 
     def releaseCommands(self, commands: Commands):
-        for command in commands:
+        for command in commands[::-1]:
             self.release(command)
 
     def press(self, command: Command):
@@ -78,7 +78,7 @@ class InputDeviceListener:
     def pressSequence(self, sequence:Sequence):
         for command in sequence:
             self.press(command)
-        for command in sequence:
+        for command in sequence[::-1]:
             self.release(command)
 
     def pressKeyboard(self, command:Keyboard):

--- a/tests/test_hid.py
+++ b/tests/test_hid.py
@@ -146,7 +146,7 @@ class TestInputDevice(TestCase):
         listener.pressed(keys, 3)
 
         macropad.keyboard.press.assert_has_calls([mock.call(0xE1), mock.call(0x04)])
-        macropad.keyboard.release.assert_has_calls([mock.call(0xE1), mock.call(0x04)])
+        macropad.keyboard.release.assert_has_calls([mock.call(0x04), mock.call(0xE1)])
 
     def test_release_sequence(self):
         keys = MockKeys([], None)
@@ -175,5 +175,5 @@ class TestInputDevice(TestCase):
         listener.register(keys)
         listener.released(keys, 2)
 
-        macropad.keyboard.release.assert_has_calls([mock.call(0x04), mock.call(0x05)])
+        macropad.keyboard.release.assert_has_calls([mock.call(0x05), mock.call(0x04)])
         macropad.keyboard.press.assert_not_called()


### PR DESCRIPTION
Release pressed keys in reverse order. It is sometimes useful to define a macro that continues to hold down a key chord for as long as the macro key is held. Some examples include, on macOS, command-tab or command-grave-accent for switching apps or windows.

Such chords usually press the modifier keys first. The modifier keys should be released last, to avoid sending unwanted keystrokes to applications.

This could cause backward-incompatible changes in some use cases, so I am willing to accept changes to make this conditional on some additional configuration.